### PR TITLE
Set animation to start when percentage is 0.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,4 +73,8 @@ dependencies {
     // Kotlin
     implementation "androidx.navigation:navigation-fragment-ktx:2.5.2"
     implementation "androidx.navigation:navigation-ui-ktx:2.5.2"
+
+    // by viewmodels
+    implementation 'androidx.activity:activity-ktx:1.6.0'
+    implementation 'androidx.fragment:fragment-ktx:1.5.3'
 }

--- a/app/src/main/java/com/hig/autocrypt/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/hig/autocrypt/ui/main/MainFragment.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.hig.autocrypt.R
 import com.hig.autocrypt.databinding.FragmentMainBinding
@@ -19,7 +20,7 @@ class MainFragment : Fragment() {
         private val TAG: String = "로그"
     }
 
-    private lateinit var viewModel: MainViewModel
+    private val viewModel: MainViewModel by viewModels()
     private lateinit var binding: FragmentMainBinding
 
     override fun onCreateView(
@@ -36,13 +37,8 @@ class MainFragment : Fragment() {
         Log.d(TAG,"MainFragment - onViewCreated() called")
         super.onViewCreated(view, savedInstanceState)
 
-        setViewModel()
         setObserver()
-        viewModel.makePercentageEighty()
-    }
-
-    private fun setViewModel() {
-        viewModel = MainViewModel()
+        startInitAnimation()
     }
 
     private fun setObserver() {
@@ -54,6 +50,14 @@ class MainFragment : Fragment() {
                     binding.progressMainLoadingApi.progress = it
                 }
             }
+        }
+    }
+
+    private fun startInitAnimation() {
+        Log.d(TAG,"MainFragment - startInitAnimation() viewmodel.downloadPercentage.value : ${viewModel.downloadPercentage.value} called")
+
+        if (viewModel.downloadPercentage.value == 0) {
+            viewModel.makePercentageEighty()
         }
     }
 }


### PR DESCRIPTION
When rotate display. percentage animation is restarted. 
원인 1 : 뷰모델을 매번 새로 만듬. 기본 생성자로 뷰모델을 만들면 화면 회전을 할 때마다 뷰모델 객체를 새로 만든다. 
해결 1 : by viewModels()로 뷰모델을 초기화. viewmodels로 초기화하면 라이프사이클을 현재 요소와 같이 한다. 
원인 2 : 현재 애니메이션이 진행 중인줄 모른다.
해결 2 : 여러 가지 방법이 있겠지만, 현재는 퍼센티지가 0일 때만 애니메이션을 진행하게 했다. 다른 방법은 isPercentageAnimationStart 같이 조건을 줘서 시작했으면 애니메이션을 새로 시작하지 않게 하는 방법이 있다.