### PR TITLE
Hilt 의존성 추가 및 세팅

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-android'
     id 'kotlin-kapt'
+    id 'dagger.hilt.android.plugin'
 }
 
 android {
@@ -42,6 +43,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    namespace 'com.hig.autocrypt'
 }
 
 dependencies {
@@ -89,4 +91,8 @@ dependencies {
 
     // To use Kotlin annotation processing tool (kapt)
     kapt "androidx.room:room-compiler:$room_version"
+
+    // Hilt Setting
+    implementation "com.google.dagger:hilt-android:2.38.1"
+    kapt "com.google.dagger:hilt-compiler:2.38.1"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.hig.autocrypt">
+    xmlns:tools="http://schemas.android.com/tools">
     <!-- Permission for retrofit http request -->
     <uses-permission android:name="android.permission.INTERNET" />
     <application
+        android:name=".AutocryptApplication"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/Theme.Autocrypt"

--- a/app/src/main/java/com/hig/autocrypt/AutocryptApplication.kt
+++ b/app/src/main/java/com/hig/autocrypt/AutocryptApplication.kt
@@ -1,0 +1,8 @@
+package com.hig.autocrypt
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class AutocryptApplication: Application() {
+}

--- a/app/src/main/java/com/hig/autocrypt/MainActivity.kt
+++ b/app/src/main/java/com/hig/autocrypt/MainActivity.kt
@@ -5,7 +5,9 @@ import android.os.Bundle
 import android.util.Log
 import androidx.databinding.DataBindingUtil
 import com.hig.autocrypt.databinding.ActivityMainBinding
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
 
     companion object {

--- a/app/src/main/java/com/hig/autocrypt/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/hig/autocrypt/ui/main/MainFragment.kt
@@ -12,8 +12,10 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.hig.autocrypt.R
 import com.hig.autocrypt.databinding.FragmentMainBinding
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 
+@AndroidEntryPoint
 class MainFragment : Fragment() {
 
     companion object {

--- a/app/src/main/java/com/hig/autocrypt/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/hig/autocrypt/ui/main/MainViewModel.kt
@@ -7,10 +7,13 @@ import androidx.lifecycle.viewModelScope
 import com.hig.autocrypt.dto.PublicHealth
 import com.hig.autocrypt.dto.Response
 import com.hig.autocrypt.model.CoronaCenterRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
 
-class MainViewModel(application: Application) : AndroidViewModel(application) {
+@HiltViewModel
+class MainViewModel @Inject constructor( application: Application) : AndroidViewModel(application) {
     companion object {
         private const val TAG: String = "로그"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    dependencies {
+        // Setting hilt dependency.
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.38.1'
+    }
+}
+
 plugins {
-    id 'com.android.application' version '7.2.2' apply false
-    id 'com.android.library' version '7.2.2' apply false
+    id 'com.android.application' version '7.3.0' apply false
+    id 'com.android.library' version '7.3.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 


### PR DESCRIPTION
Hilt 세팅을 추가했다.
Hilt에 특정 클래스에 속한 멤버변수에 의존성을 주입하려면 AndroidEntryPoint 어노테이션을 사용해야되나보다.
Application을 상속하는 클래스도 만들어줘야 한다.