### PR TITLE
bug fix) 화면 회전하면 콜백이 안먹힘

### DIFF
--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -10,7 +10,9 @@
         android:label="MainFragment" >
         <action
             android:id="@+id/action_mainFragment_to_mapFragment"
-            app:destination="@id/mapFragment" />
+            app:destination="@id/mapFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="true"/>
     </fragment>
     <fragment
         android:id="@+id/mapFragment"


### PR DESCRIPTION
문제 발생 상황 : mainFragment에서 mapFragment로 이동 후에 화면을 회전하고 뒤로 가기 버튼을 누르면 mainFragment화면으로 이동한다.
 원래는 "앱을 종료하려면 뒤로가기 버튼을 한 번 더 누르시오."라고 토스트가 뜬다.

 해결 방법 : Navigation에 백스택과 관련 있어보였다.
 따라서, mapFragment로 이동하는 순간 mainFragment를 네비게이션의 백스택에서 제거했다.