### PR TITLE
다운로드 기능 수정

### DIFF
--- a/app/src/main/java/com/hig/autocrypt/model/CoronaCenterRepository.kt
+++ b/app/src/main/java/com/hig/autocrypt/model/CoronaCenterRepository.kt
@@ -16,8 +16,8 @@ class CoronaCenterRepository(application: Application) {
     private val db = Room.databaseBuilder(application, AppDatabase::class.java, "app-database").build()
     private val coronaCenterDao = db.coronaCenterDao()
 
-    suspend fun getCoronaCenter(page: Int, perPage: Int): Response {
-        return coronaRequestRetrofit.getPublicHealthOffices(page = page, perPage = perPage)
+    suspend fun getPublicHealthCenters(page: Int, perPage: Int): Response {
+        return coronaRequestRetrofit.getPublicHealthCenters(page = page, perPage = perPage)
     }
 
     suspend fun insertCoronaCenter(publicHealth: PublicHealth) {

--- a/app/src/main/java/com/hig/autocrypt/util/CoronaRequest.kt
+++ b/app/src/main/java/com/hig/autocrypt/util/CoronaRequest.kt
@@ -7,7 +7,7 @@ import retrofit2.http.Query
 
 interface CoronaRequest {
     @GET("15077586/v1/centers")
-    suspend fun getPublicHealthOffices(
+    suspend fun getPublicHealthCenters(
         @Query("page")page: Int = 1,
         @Query("perPage")perPage: Int = 10,
         @Query("returnType")returnType: String = "json",

--- a/app/src/main/java/com/hig/autocrypt/view/MainFragment.kt
+++ b/app/src/main/java/com/hig/autocrypt/view/MainFragment.kt
@@ -42,8 +42,8 @@ class MainFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         setObserver()
+        startDownload()
         startInitAnimation()
-        viewModel.refreshCoronaCenterData()
     }
 
     private fun setObserver() {
@@ -58,6 +58,13 @@ class MainFragment : Fragment() {
                     findNavController().navigate(R.id.action_mainFragment_to_mapFragment)
                 }
             }
+        }
+    }
+
+    private fun startDownload() {
+        Log.d(TAG,"MainFragment - startDownload() : downloadPercentage : ${viewModel.downloadPercentage.value} called")
+        if (viewModel.downloadPercentage.value == 0) {
+            viewModel.refreshCoronaCenterData()
         }
     }
 

--- a/app/src/main/java/com/hig/autocrypt/view/MainFragment.kt
+++ b/app/src/main/java/com/hig/autocrypt/view/MainFragment.kt
@@ -70,7 +70,6 @@ class MainFragment : Fragment() {
 
     private fun startInitAnimation() {
         Log.d(TAG,"MainFragment - startInitAnimation() viewmodel.downloadPercentage.value : ${viewModel.downloadPercentage.value} called")
-
         if (viewModel.downloadPercentage.value == 0) {
             viewModel.makePercentageEighty()
         }

--- a/app/src/main/java/com/hig/autocrypt/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/hig/autocrypt/viewmodel/MainViewModel.kt
@@ -13,12 +13,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
 
 @HiltViewModel
-class MainViewModel @Inject constructor( application: Application) : AndroidViewModel(application) {
+class MainViewModel @Inject constructor(application: Application) : AndroidViewModel(application) {
     companion object {
         private const val TAG: String = "로그"
     }
 
-    private val _downloadPercentage = MutableStateFlow<Int>(0)
+    private val _downloadPercentage = MutableStateFlow(0)
     val downloadPercentage = _downloadPercentage
 
     private lateinit var jobOfZeroToEightyAni: Job

--- a/app/src/main/java/com/hig/autocrypt/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/hig/autocrypt/viewmodel/MainViewModel.kt
@@ -55,7 +55,7 @@ class MainViewModel @Inject constructor( application: Application) : AndroidView
 
             for (page in 1..10) {
                 val def = async {
-                    val response = getCoronaCentersFromApi(page = page, 10)
+                    val response = getPublicHealthCentersFromApi(page = page, 10)
 
                     // Save to room
                     response.data.forEach { publicHealth ->
@@ -84,8 +84,8 @@ class MainViewModel @Inject constructor( application: Application) : AndroidView
         coronaCenterRepository.insertCoronaCenter(publicHealth)
     }
 
-    private suspend fun getCoronaCentersFromApi(page: Int, perPage: Int = 10): Response {
+    private suspend fun getPublicHealthCentersFromApi(page: Int, perPage: Int = 10): Response {
         Log.d(TAG,"MainViewModel - getCoronaCentersFromApi() called")
-        return coronaCenterRepository.getCoronaCenter(page, perPage)
+        return coronaCenterRepository.getPublicHealthCenters(page, perPage)
     }
 }

--- a/app/src/main/java/com/hig/autocrypt/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/hig/autocrypt/viewmodel/MainViewModel.kt
@@ -22,7 +22,6 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
     val downloadPercentage = _downloadPercentage
 
     private lateinit var jobOfZeroToEightyAni: Job
-
     private val coronaCenterRepository: CoronaCenterRepository = CoronaCenterRepository(application)
 
     fun makePercentageEighty() {


### PR DESCRIPTION
MainFragment에서 onViewCreate 라이프사이클마다 다운로드 기능을 실행하는 문제가 있었다.
따라서, 다운로드 퍼센티지가 0이 아닐 때(다운로드가 진행 중)만 다운로드를 실행하게 코드를 수정하여 재다운로드를 막았다.